### PR TITLE
Deactivate output buffer to fix truncated image output

### DIFF
--- a/src/Intervention/Image/ImageCacheController.php
+++ b/src/Intervention/Image/ImageCacheController.php
@@ -20,6 +20,9 @@ class ImageCacheController extends BaseController
      */
     public function getResponse($template, $filename)
     {
+        // Ensure that output buffering is off
+        ob_end_clean();
+        
         switch (strtolower($template)) {
             case 'original':
                 return $this->getOriginal($filename);


### PR DESCRIPTION
In some server configurations, output buffering will cause the image content to be truncated by approximately 5 rows of pixels. I can confirm that this happened with both PHP 7.4 and 8.0, using both GD and Imagick drivers. 

The solution is to just end output buffering before processing the response.

I was able to recreate the original issue by using `ob_start()` on the affected line using my local MAMP environment. Switching it to `ob_end_clean()` resolve the issue on both my development and the production machines.

